### PR TITLE
fix crashing due to error "can't convert to color: type=0x2"

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,7 +9,7 @@
 
     </style>
 
-    <style name="TextLabel" parent="TextAppearance.AppCompat">
+    <style name="TextLabel" parent="ThemeOverlay.AppCompat.Light">
         <item name="android:textColorHint">@android:color/white</item>
         <item name="android:textSize">20sp</item>
         <item name="colorAccent">@android:color/white</item>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="VoucherCodeLabel" parent="TextAppearance.AppCompat">
+    <style name="VoucherCodeLabel" parent="ThemeOverlay.AppCompat.Light">
         <item name="android:textSize">20dp</item>
         <item name="android:textColor">@android:color/white</item>
         <item name="android:textColorHint">@android:color/white</item>


### PR DESCRIPTION
Using theme parent `TextAppearance.AppCompat` was causing an error on Asus Zenfone 5 (Android 4.2.2):

```
android.view.InflateException: Binary XML file line #36: Error inflating class EditText
        ...
Caused by: android.view.InflateException: Binary XML file line #36: Error inflating class EditText
        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:713)
        ....
Caused by: java.lang.UnsupportedOperationException: Can't convert to color: type=0x2
        at android.content.res.TypedArray.getColor(TypedArray.java:327)
        at android.widget.TextView.<init>(TextView.java:700)
        at android.widget.EditText.<init>(EditText.java:61)
        at android.support.v7.widget.AppCompatEditText.<init>(AppCompatEditText.java:58)
```
